### PR TITLE
feat: ⭐️ Implement filter on ActivitySession

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,5 +60,9 @@ group :development, :test do
   gem "factory_bot_rails" # https://github.com/thoughtbot/factory_bot_rails
   gem "faker" # https://github.com/faker-ruby/faker
 
+  # https://github.com/DatabaseCleaner/database_cleaner
+  gem "database_cleaner-active_record", "~> 2.2.0"
+  # gem "database_cleaner-redis", "~> 2.0.0"
+
   gem "dotenv", "3.1.8" # https://github.com/bkeepers/dotenv
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,10 @@ GEM
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
+    database_cleaner-active_record (2.2.0)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0.0)
+    database_cleaner-core (2.0.1)
     date (3.4.1)
     debug (1.10.0)
       irb (~> 1.10)
@@ -101,7 +105,7 @@ GEM
     diff-lcs (1.6.1)
     dotenv (3.1.8)
     drb (2.2.1)
-    ed25519 (1.3.0)
+    ed25519 (1.4.0)
     erubi (1.13.1)
     et-orbi (1.2.11)
       tzinfo
@@ -216,8 +220,8 @@ GEM
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (3.1.13)
-    rack-session (2.1.0)
+    rack (3.1.14)
+    rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
     rack-test (2.2.0)
@@ -265,7 +269,7 @@ GEM
     rspec-expectations (3.13.4)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.3)
+    rspec-mocks (3.13.4)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-rails (8.0.0)
@@ -277,7 +281,7 @@ GEM
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
     rspec-support (3.13.3)
-    rubocop (1.75.4)
+    rubocop (1.75.5)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -371,6 +375,7 @@ DEPENDENCIES
   bcrypt (= 3.1.20)
   bootsnap
   brakeman
+  database_cleaner-active_record (~> 2.2.0)
   debug
   dotenv (= 3.1.8)
   factory_bot_rails

--- a/app/controllers/api/activity_session_controller.rb
+++ b/app/controllers/api/activity_session_controller.rb
@@ -84,11 +84,15 @@ module Api
 
     def get_activity_sessions(user_ids)
       filter_ongoing = ActiveModel::Type::Boolean.new.cast(params[:ongoing]) if params[:ongoing].present?
+      filter_finished = ActiveModel::Type::Boolean.new.cast(params[:finished]) if params[:finished].present?
+      filter_from_last_week = ActiveModel::Type::Boolean.new.cast(params[:from_last_week]) if params[:from_last_week].present?
       records = ActivitySession.where(
         user_id: user_ids,
         activity_type: @activity_type,
       )
-      records = records.where(clock_out: nil) if filter_ongoing
+      records = records.ongoing if filter_ongoing
+      records = records.finished if filter_finished
+      records = records.from_last_week if filter_from_last_week
       records = records.order(created_at: :desc)
       records.includes(:user)
     end

--- a/app/models/activity_session.rb
+++ b/app/models/activity_session.rb
@@ -9,7 +9,7 @@ class ActivitySession < ApplicationRecord
 
   validate :clock_out_after_clock_in
 
-  scope :incomplete, -> { where(clock_in: nil).or(where(clock_out: nil)) }
+  scope :ongoing, -> { where(clock_out: nil) }
   scope :finished, -> { where("clock_in is not null and clock_out is not null") }
 
   scope :from_last_week, -> { where("clock_in >= ?", 1.week.ago) }

--- a/spec/models/activity_session_spec.rb
+++ b/spec/models/activity_session_spec.rb
@@ -40,11 +40,11 @@ RSpec.describe ActivitySession, type: :model do
     let!(:activity_session2) { create :activity_session, user: user, clock_in: 5.days.ago, clock_out: 1.day.ago }
     let!(:activity_session3) { create :activity_session, user: user, clock_in: 2.weeks.ago, clock_out: 2.days.ago }
 
-    describe ".incomplete" do
+    describe ".ongoing" do
       it "returns sessions with nil clock_in or clock_out" do
-        expect(ActivitySession.incomplete).to include(activity_session1)
-        expect(ActivitySession.incomplete).not_to include(activity_session2)
-        expect(ActivitySession.incomplete).not_to include(activity_session3)
+        expect(ActivitySession.ongoing).to include(activity_session1)
+        expect(ActivitySession.ongoing).not_to include(activity_session2)
+        expect(ActivitySession.ongoing).not_to include(activity_session3)
       end
     end
 

--- a/spec/supports/database_cleaner_support.rb
+++ b/spec/supports/database_cleaner_support.rb
@@ -1,0 +1,75 @@
+# Installing database_cleaner:
+
+# 0. Check spec/support dir is auto-required in spec/rails_helper.rb.
+#
+# 1. Add database_cleaner to Gemfile:
+#
+# group :test do
+#   gem 'database_cleaner'
+# end
+
+# 2. IMPORTANT! Delete the "config.use_transactional_fixtures = ..." line
+#    in spec/rails_helper.rb (we're going to configure it in this file you're
+#    reading instead).
+
+# 3. Create a file like this one you're reading in spec/support/database_cleaner.rb:
+RSpec.configure do |config|
+  config.use_transactional_fixtures = false
+
+  config.before(:suite) do
+    if config.use_transactional_fixtures?
+
+      raise(<<-MSG)
+
+        Delete line `config.use_transactional_fixtures = true` from rails_helper.rb
+        (or set it to false) to prevent uncommitted transactions being used in
+        JavaScript-dependent specs.
+
+        During testing, the Ruby app server that the JavaScript browser driver
+        connects to uses a different database connection to the database connection
+        used by the spec.
+
+        This Ruby app server database connection would not be able to see data that
+        has been setup by the spec's database connection inside an uncommitted
+        transaction.
+
+        Disabling the use_transactional_fixtures setting helps avoid uncommitted
+        transactions in JavaScript-dependent specs, meaning that the Ruby app server
+        database connection can see any data set up by the specs.
+
+      MSG
+
+    end
+  end
+
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each, type: :feature) do
+    # :rack_test driver's Rack app under test shares database connection
+    # with the specs, so we can use transaction strategy for speed.
+    driver_shares_db_connection_with_specs = Capybara.current_driver == :rack_test
+
+    if driver_shares_db_connection_with_specs
+      DatabaseCleaner.strategy = :transaction
+    else
+      # Non-:rack_test driver is probably a driver for a JavaScript browser
+      # with a Rack app under test that does *not* share a database
+      # connection with the specs, so we must use truncation strategy.
+      DatabaseCleaner.strategy = :truncation
+    end
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
+end


### PR DESCRIPTION
feat: ⭐️ Implement filter on ActivitySession

- Add Gem database cleaner for more confident and consistent data spec
- Filters:
  - filter_ongoing using params ?ongoing=yes|true|1 -> returning non clocked-out activity_session
  - filter_finished using params ?finished=yes|true|1 -> returning only finished clock-in and clock-out
  - filter_from_last_week params ?from_last_week=yes|true|1 -> returning activity_session created_at > 1.week.ago
- Complete the context test for those filter